### PR TITLE
Fixed annoying bug during build using make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -843,5 +843,9 @@ fi
 
 echo "Building $OMR_DIST for the target $OMR_TARGET with kernel ${OMR_KERNEL}"
 make defconfig
-make IGNORE_ERRORS=m "$@"
-echo "Done"
+if make IGNORE_ERRORS=m "$@"
+then
+       echo "Done"
+else
+       cd $OMR_TARGET/source && make
+fi


### PR DESCRIPTION
More info about bug here: https://github.com/Ysurac/openmptcprouter/issues/2437

@Ysurac,
Hi, thank you very much for the work done, this project is grandiose, I am waiting release version.
But there are disadvantages, namely an inconvenient and longtime build, because make error we have to restart build process again, which takes even more time (on my computer, build takes ~30 min).
I have commit that will help everyone not to waste extra time on reinput command.